### PR TITLE
introduce a new concept: offer type

### DIFF
--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -86,7 +86,7 @@ type PriceDimensionRaw struct {
 // PriceRaw is the raw price struct marshaled from the aws json file
 type PriceRaw struct {
 	Dimension map[string]PriceDimensionRaw `json:"priceDimensions"`
-	Term      *client.OfferPayload         `json:"termAttributes"`
+	Term      *client.ChargePayload        `json:"termAttributes"`
 }
 
 // InfoEndPoint is the instance info endpoint
@@ -147,13 +147,13 @@ func extractPrice(rawData *rawJSON) ([]*client.Offer, error) {
 						return nil, fmt.Errorf("Fail to parse the price to type FLOAT64, value: %v, [internal]: %v", dimension.PricePerUnit[client.CurrencyUSD], err)
 					}
 					price := &client.Offer{
-						ID:          string(rateCode),
-						InstanceID:  string(instanceID),
-						Type:        chargeType,
-						Payload:     offer.Term,
-						Description: dimension.Description,
-						Unit:        dimension.Unit,
-						USD:         USDFloat,
+						ID:            string(rateCode),
+						InstanceID:    string(instanceID),
+						ChargeType:    client.ChargeType(chargeType),
+						ChargePayload: offer.Term,
+						Description:   dimension.Description,
+						Unit:          dimension.Unit,
+						USD:           USDFloat,
 					}
 					priceList = append(priceList, price)
 				}

--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,7 @@ type Offer struct {
 	InstanceID string
 
 	ChargeType ChargeType
-	// Payload is nil when the ChargeType is onDemand.
+	// Payload is present when the ChargeType is Reserved, otherwise nil.
 	ChargePayload *ChargePayload
 
 	RegionList  []string

--- a/client/client.go
+++ b/client/client.go
@@ -1,21 +1,21 @@
 package client
 
-// EngineType is the type of the database engine
-// It should be noticed that the price of different engine may differ
+// EngineType is the type of the database engine.
+// It should be noticed that the price of different engine may differ.
 type EngineType string
 
 const (
-	// EngineTypeMySQL is the engine type for MySQL
+	// EngineTypeMySQL is the engine type for MySQL.
 	EngineTypeMySQL = "MYSQL"
-	// EngineTypePostgreSQL is the engine type for PostgreSQL
+	// EngineTypePostgreSQL is the engine type for PostgreSQL.
 	EngineTypePostgreSQL = "POSTGRES"
-	// EngineTypeOracle is the engine type for Oracle
+	// EngineTypeOracle is the engine type for Oracle.
 	EngineTypeOracle = "ORACLE"
-	// EngineTypeSQLServer is the engine type for SQLServer
+	// EngineTypeSQLServer is the engine type for SQLServer.
 	EngineTypeSQLServer = "SQLSERVER"
 )
 
-// Instance is the api message of the instance
+// Instance is the api message of the instance.
 type Instance struct {
 	ID                 string
 	ServiceCode        string     `json:"servicecode"`
@@ -30,13 +30,13 @@ type Instance struct {
 	DatabaseEngine     EngineType `json:"databaseEngine"`
 }
 
-// ChargeType is the charge type of the price
+// ChargeType is the charge type of the price.
 type ChargeType string
 
 const (
-	// ChargeTypeOnDemand is the on demand type of the price
+	// ChargeTypeOnDemand is the on demand type of the price.
 	ChargeTypeOnDemand ChargeType = "OnDemand"
-	// ChargeTypeReserved is the reserved type of the price
+	// ChargeTypeReserved is the reserved type of the price.
 	ChargeTypeReserved ChargeType = "Reserved"
 )
 
@@ -45,35 +45,37 @@ const (
 type OfferType string
 
 const (
-	// OfferTypeInstance is the offer type that provide a specified instance as a basic unit
+	// OfferTypeInstance is the offer type that provide a specified instance as a basic unit.
 	OfferTypeInstance OfferType = "Instance"
-	// OfferTypeRAM is the offer type that provide a RAM as a basic unit
+	// OfferTypeRAM is the offer type that provide a RAM as a basic unit.
 	OfferTypeRAM OfferType = "RAM"
-	// OfferTypeVCPU is the offer type that provide a VCPU as a basic unit
+	// OfferTypeVCPU is the offer type that provide a VCPU as a basic unit.
 	OfferTypeVCPU OfferType = "VCPU"
 )
 
-// Currency is the type of the currency
+// Currency is the type of the currency.
 type Currency string
 
-// CurrencyUSD is the type of the currency of USC
+// CurrencyUSD is the type of the currency of USC.
 const CurrencyUSD = "USD"
 
-// ChargePayload is the charge payload of the offer
+// ChargePayload is the charge payload of the offer.
 type ChargePayload struct {
 	LeaseContractLength string `json:"leaseContractLength"`
 	PurchaseOption      string `json:"purchaseOption"`
 }
 
-// Offer is the api message of an Offer
+// Offer is the api message of an Offer.
 type Offer struct {
 	ID string
 
-	OfferType  OfferType
-	InstanceID string // If OfferType is not Instance, InstanceID would be nil
+	OfferType OfferType
+	// If OfferType is not Instance, InstanceID would be empty, otherwise InstanceID may be the sku of that instance.
+	InstanceID string
 
-	ChargeType    ChargeType
-	ChargePayload *ChargePayload // Payload is nil when the ChargeType is onDemand
+	ChargeType ChargeType
+	// Payload is nil when the ChargeType is onDemand.
+	ChargePayload *ChargePayload
 
 	RegionList  []string
 	Description string
@@ -81,7 +83,7 @@ type Offer struct {
 	USD         float64
 }
 
-// Client is the client for http request
+// Client is the client for http request.
 type Client interface {
 	GetInstancePrice()
 }

--- a/client/client.go
+++ b/client/client.go
@@ -30,14 +30,27 @@ type Instance struct {
 	DatabaseEngine     EngineType `json:"databaseEngine"`
 }
 
-// OfferType is the charging type of the price
+// ChargeType is the charge type of the price
+type ChargeType string
+
+const (
+	// ChargeTypeOnDemand is the on demand type of the price
+	ChargeTypeOnDemand ChargeType = "OnDemand"
+	// ChargeTypeReserved is the reserved type of the price
+	ChargeTypeReserved ChargeType = "Reserved"
+)
+
+// OfferType is the type of the smallest offer type of a offer.
+// Some vendors may provide offer at a VCPU/RAM level while others may only provide a specified instance.
 type OfferType string
 
 const (
-	// OfferTypeOnDemand is the on demand type of the price
-	OfferTypeOnDemand OfferType = "OnDemand"
-	// OfferTypeReserved is the reserved type of the price
-	OfferTypeReserved OfferType = "Reserved"
+	// OfferTypeInstance is the offer type that provide a specified instance as a basic unit
+	OfferTypeInstance OfferType = "Instance"
+	// OfferTypeRAM is the offer type that provide a RAM as a basic unit
+	OfferTypeRAM OfferType = "RAM"
+	// OfferTypeVCPU is the offer type that provide a VCPU as a basic unit
+	OfferTypeVCPU OfferType = "VCPU"
 )
 
 // Currency is the type of the currency
@@ -46,21 +59,23 @@ type Currency string
 // CurrencyUSD is the type of the currency of USC
 const CurrencyUSD = "USD"
 
-// OfferPayload is the term Payload of the price
-type OfferPayload struct {
+// ChargePayload is the charge payload of the offer
+type ChargePayload struct {
 	LeaseContractLength string `json:"leaseContractLength"`
 	PurchaseOption      string `json:"purchaseOption"`
 }
 
 // Offer is the api message of an Offer
 type Offer struct {
-	ID         string
-	InstanceID string
+	ID string
 
-	Type OfferType
-	// Term is nil when the ChargeType is onDemand
-	Payload *OfferPayload
+	OfferType  OfferType
+	InstanceID string // If OfferType is not Instance, InstanceID would be nil
 
+	ChargeType    ChargeType
+	ChargePayload *ChargePayload // Payload is nil when the ChargeType is onDemand
+
+	RegionList  []string
 	Description string
 	Unit        string
 	USD         float64

--- a/client/client.go
+++ b/client/client.go
@@ -71,6 +71,7 @@ type Offer struct {
 
 	OfferType OfferType
 	// If OfferType is not Instance, InstanceID would be empty, otherwise InstanceID may be the sku of that instance.
+	// e.g. AWS: 9QH3PUGXCYKNCYPB, GCP: 0009-6F35-3126
 	InstanceID string
 
 	ChargeType ChargeType

--- a/store/dbInstance.go
+++ b/store/dbInstance.go
@@ -19,7 +19,7 @@ type TermPayload struct {
 // Term is the pricing term of a given instance
 type Term struct {
 	DatabaseEngine client.EngineType `json:"databaseEngine"`
-	Type           client.OfferType  `json:"type"`
+	Type           client.ChargeType `json:"type"`
 	Payload        *TermPayload      `json:"payload"`
 
 	Unit        string  `json:"unit"`
@@ -64,15 +64,15 @@ func Convert(priceList []*client.Offer, instanceList []*client.Instance) ([]*DBI
 	for _, offer := range priceList {
 		var payload *TermPayload
 		// Only reserved type has payload field
-		if offer.Type == client.OfferTypeReserved {
+		if offer.ChargeType == client.ChargeTypeReserved {
 			payload = &TermPayload{
-				LeaseContractLength: offer.Payload.LeaseContractLength,
-				PurchaseOption:      offer.Payload.PurchaseOption,
+				LeaseContractLength: offer.ChargePayload.LeaseContractLength,
+				PurchaseOption:      offer.ChargePayload.PurchaseOption,
 			}
 		}
 
 		term := &Term{
-			Type:        offer.Type,
+			Type:        offer.ChargeType,
 			Payload:     payload,
 			Unit:        offer.Unit,
 			USD:         offer.USD,


### PR DESCRIPTION
Before, the smallest service unit is at instance level.
But GCP provides services at VCPU/RAM level, the current model cannot support this.

So a new field `OfferType` is necessary to the struct `Offer`, distinguishing the difference between them.