### PR TITLE
store region code and map the code to the relevant region at the frontend.

### DIFF
--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -54,7 +54,8 @@ func (e EngineType) String() string {
 
 // instance is the api message of the Instance for AWS specifically
 type instance struct {
-	ID             string
+	ID string
+	// The tag here does not follow small-camel naming style, it is intended for the AWS name it this way.
 	ServiceCode    string `json:"servicecode"`
 	RegionCode     string `json:"regionCode"`
 	Type           string `json:"instanceType"`

--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -56,7 +56,7 @@ func (e EngineType) String() string {
 type instance struct {
 	ID             string
 	ServiceCode    string `json:"servicecode"`
-	Location       string `json:"location"`
+	RegionCode     string `json:"regionCode"`
 	Type           string `json:"instanceType"`
 	InstanceFamily string `json:"instanceFamily"`
 	// Noted that this is a api mmessage from AWS, so we still use vcpu for unmarshaling the info,
@@ -214,8 +214,7 @@ func fillInstancePayload(instanceRecord instanceRecord, offerList []*client.Offe
 		}
 		if _, ok := offerMap[instanceSKU]; ok {
 			for _, offer := range offerMap[instanceSKU] {
-				// The region info of the offer is stored in the instance, we need set the region info here as well.
-				offer.RegionList = []string{entry.Attributes.Location}
+				offer.RegionList = []string{entry.Attributes.RegionCode}
 				offer.InstancePayload = instance
 			}
 		}

--- a/frontend/src/components/CostTable.vue
+++ b/frontend/src/components/CostTable.vue
@@ -137,7 +137,7 @@ const columns: any = computed(() => [
           return stringComp;
         }
 
-        // if tow region are identical, sort them with instance's id
+        // If tow region are identical, sort them with instance id.
         return row1.id - row2.id;
       },
       multiple: 1,

--- a/frontend/src/components/CostTableRegionMenu.vue
+++ b/frontend/src/components/CostTableRegionMenu.vue
@@ -4,18 +4,18 @@
       :value="(props.regionList as any)"
       @update-value="handleUpdateRegion"
     >
-      <n-grid :y-gap="4" :cols="`2 600:3 800:4`">
+      <n-grid :y-gap="4" :cols="`2 760:3 980:4`">
         <n-gi v-for="(region, i) in availableRegionList" :key="i">
           <n-checkbox :value="region.name" :label="region.name" />
           <n-avatar
-            v-if="region.provider.has('AWS')"
+            v-if="region.providerCode.has('AWS')"
             :src="ProviderIcon.AWS"
             color="none"
             :size="20"
             class="align-bottom ml-1"
           />
           <n-avatar
-            v-if="region.provider.has('GCP')"
+            v-if="region.providerCode.has('GCP')"
             :src="ProviderIcon.GCP"
             color="none"
             :size="16"

--- a/frontend/src/stores/dbInstance.ts
+++ b/frontend/src/stores/dbInstance.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { AvailableRegion, DBInstance, DBInstanceId } from "../types";
+import { AvailableRegion, DBInstance, DBInstanceId, Region } from "../types";
 import { getRegionName } from "../util";
 interface State {
   dbInstanceList: DBInstance[];
@@ -32,7 +32,7 @@ export const useDBInstanceStore = defineStore("dbInstance", {
             regionMap.set(regionName, newMap);
           }
 
-          regionMap.get(regionName)?.set(db.cloudProvider, region.name);
+          regionMap.get(regionName)?.set(db.cloudProvider, region.code);
         });
       });
 
@@ -51,7 +51,7 @@ export const useDBInstanceStore = defineStore("dbInstance", {
       const regionSet = new Set<string>();
       state.dbInstanceList.forEach((db) => {
         db.regionList.forEach((region) => {
-          regionSet.add(getRegionName(region.name));
+          regionSet.add(getRegionName(region.code));
         });
       });
 

--- a/frontend/src/stores/dbInstance.ts
+++ b/frontend/src/stores/dbInstance.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { AvailableRegion, DBInstance, DBInstanceId } from "../types";
-
+import { getRegionName } from "../util";
 interface State {
   dbInstanceList: DBInstance[];
 }
@@ -23,24 +23,39 @@ export const useDBInstanceStore = defineStore("dbInstance", {
         return dbInstance[0];
       },
     getAvailableRegionList: (state) => (): AvailableRegion[] => {
-      const regionMap = new Map<string, Set<string>>();
-
+      const regionMap = new Map<string, Map<string, string>>();
       state.dbInstanceList.forEach((db) => {
-        db.regionList.forEach((r) => {
-          if (regionMap.has(r.name)) {
-            regionMap.get(r.name)?.add(db.cloudProvider);
-          } else {
-            regionMap.set(r.name, new Set<string>(db.cloudProvider));
+        db.regionList.forEach((region: Region) => {
+          const regionName = getRegionName(region.code);
+          if (!regionMap.has(regionName)) {
+            const newMap = new Map<string, string>();
+            regionMap.set(regionName, newMap);
           }
+
+          regionMap.get(regionName)?.set(db.cloudProvider, region.name);
         });
       });
 
-      const regionList: AvailableRegion[] = [];
-      regionMap.forEach((providerSet, regionName) => {
-        regionList.push({ name: regionName, provider: providerSet });
+      const availableRegion: AvailableRegion[] = [];
+      regionMap.forEach((providerCode, regionName) => {
+        availableRegion.push({
+          name: regionName,
+          providerCode: providerCode,
+        });
       });
 
-      return regionList;
+      return availableRegion;
+    },
+
+    getAvailableRegionSet: (state) => (): Set<string> => {
+      const regionSet = new Set<string>();
+      state.dbInstanceList.forEach((db) => {
+        db.regionList.forEach((region) => {
+          regionSet.add(getRegionName(region.name));
+        });
+      });
+
+      return regionSet;
     },
   },
 

--- a/frontend/src/types/region.ts
+++ b/frontend/src/types/region.ts
@@ -2,27 +2,25 @@ import { Term } from "./term";
 import { useDBInstanceStore } from "../stores/dbInstance";
 
 export type Region = {
-  name: string;
+  code: string;
   termList: Term[];
 };
 
 export type AvailableRegion = {
   name: string;
-  provider: Set<string>;
+  // providerCode is the mapping between between provider and the region code
+  // e.g. N. Virginia is coded 'us-east-1' in AWS,  us-east4 in GCP
+  providerCode: Map<string, string>;
 };
 
 export const isValidRegion = (regionList: string[]): boolean => {
-  const availableRegion = useDBInstanceStore().getAvailableRegionList();
-  const regionSet: Set<String> = new Set<String>();
-  availableRegion.forEach((region) => {
-    regionSet.add(region.name);
-  });
-
-  for (const region of regionList) {
-    if (!regionSet.has(region)) {
-      return false;
+  const availableRegionSet = useDBInstanceStore().getAvailableRegionSet();
+  for (const idx in regionList) {
+    const region = regionList[idx];
+    if (!availableRegionSet.has(region)) {
+      return true;
     }
   }
 
-  return true;
+  return false;
 };

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -5,3 +5,82 @@ export const isEmptyArray = (arr: any[] | undefined) => {
 
   return false;
 };
+
+const regionCodeMap: Map<string, string> = new Map<string, string>([
+  // AWS
+  ["us-gov-east-1", "AWS GovCloud (US-East)"],
+  ["us-gov-west-1", "AWS GovCloud (US-West)"],
+  ["af-south-1", "Africa (Cape Town)"],
+  ["ap-east-1", "Asia Pacific (Hong Kong)"],
+  ["ap-northeast-1", "Asia Pacific (Tokyo)"],
+  ["ap-northeast-2", "Asia Pacific (Seoul)"],
+  ["ap-northeast-3", "Asia Pacific (Osaka)"],
+  ["ap-south-1", "Asia Pacific (Mumbai)"],
+  ["ap-southeast-1", "Asia Pacific (Singapore)"],
+  ["ap-southeast-2", "Asia Pacific (Sydney)"],
+  ["ap-southeast-3", "Asia Pacific (Jakarta)"],
+  ["ca-central-1", "Canada (Central)"],
+  ["eu-central-1", "Europe (Frankfurt)"],
+  ["eu-north-1", "Europe (Stockholm)"],
+  ["eu-south-1", "Europe (Milan)"],
+  ["eu-west-1", "Europe (Ireland)"],
+  ["eu-west-2", "Europe (London)"],
+  ["eu-west-3", "Europe (Paris)"],
+  ["me-south-1", "Middle East (Bahrain)"],
+  ["sa-east-1", "South America (Sao Paulo)"],
+  ["us-east-1", "US East (N. Virginia)"],
+  ["us-east-2", "US East (Ohio)"],
+  ["us-west-1", "US West (N. California)"],
+  ["us-west-2", "US West (Oregon)"],
+  ["us-west-2-lax-1", "US West (Los Angeles)"],
+
+  // GCP
+  ["asia-east1", "Asia Pacific (Taiwan)"],
+  ["asia-east2", "Asia Pacific (Hong Kong)"],
+  ["asia-northeast1", "Asia Pacific (Tokyo)"],
+  ["asia-northeast2", "Asia Pacific (Osaka)"],
+  ["asia-northeast3", "Asia Pacific (Seoul)"],
+  ["asia-south1", "Asia Pacific (Mumbai)"],
+  ["asia-south2", "Asia Pacific (Delhi)"],
+  ["asia-southeast1", "Asia Pacific (Singapore)"],
+  ["asia-southeast2", "Asia Pacific (Jakarta)"],
+  ["australia-southeast1", "Asia Pacific (Sydney)"],
+  ["australia-southeast2", "Asia Pacific (Melbourne)"],
+  ["europe-central2", "Europe (Warsaw)"],
+  ["europe-north1", "Europe (Finland)"],
+  ["europe-west1", "Europe (Belgium)"],
+  ["europe-west2", "Europe (London)"],
+  ["europe-west3", "Europe (Frankfurt)"],
+  ["europe-west4", "Europe (Netherlands)"],
+  ["europe-west6", "Europe (Zurich)"],
+  ["europe-west8", "Europe (Milan)"],
+  ["europe-west9", "Europe (Paris)"],
+  ["northamerica-northeast1", "Canada (Montréal)"],
+  ["northamerica-northeast2", "Canada (Toronto)"],
+  ["southamerica-east1", "South America (Osasco)"],
+  ["southamerica-west1", "South America (Santiago)"],
+  ["us-central1", "US Central (Iowa)"],
+  ["us-east1", "US East (South Carolina)"],
+  ["us-east4", "US East (N. Virginia)"],
+  ["us-east5", "US East (us-east5)"],
+  ["us-east7", "US East (us-east7)"],
+  ["us-west1", "US West (Oregon)"],
+  ["us-west2", "US West (Los Angeles)"],
+  ["us-west3", "US West (Salt Lake City)"],
+  ["us-west4", "US West (Las Vegas)"],
+]);
+
+export const getRegionName = (regionCode: string): string => {
+  return regionCodeMap.get(regionCode);
+};
+
+export const getRegionCode = (regionName: string): string[] => {
+  const regionCode = [];
+  regionCodeMap.forEach((_regionName, code) => {
+    if (_regionName === regionName) {
+      regionCode.push(code);
+    }
+  });
+
+  return regionCode;
+};

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -71,11 +71,14 @@ const regionCodeMap: Map<string, string> = new Map<string, string>([
 ]);
 
 export const getRegionName = (regionCode: string): string => {
-  return regionCodeMap.get(regionCode);
+  if (!regionCodeMap.has(regionCode)) {
+    return "";
+  }
+  return regionCodeMap.get(regionCode) as string;
 };
 
 export const getRegionCode = (regionName: string): string[] => {
-  const regionCode = [];
+  const regionCode: string[] = [];
   regionCodeMap.forEach((_regionName, code) => {
     if (_regionName === regionName) {
       regionCode.push(code);

--- a/store/data/test/aws-sample.json
+++ b/store/data/test/aws-sample.json
@@ -8,7 +8,7 @@
     "updatedTs": 1650810030,
     "regionList": [
       {
-        "name": "US West (Oregon)",
+        "code": "us-east-1",
         "termList": [
           {
             "databaseEngine": "POSTGRES",
@@ -127,7 +127,7 @@
         ]
       },
       {
-        "name": "Asia Pacific (Tokyo)",
+        "code": "ap-southeast-1",
         "termList": [
           {
             "databaseEngine": "MYSQL",

--- a/store/db_instance.go
+++ b/store/db_instance.go
@@ -31,7 +31,7 @@ type Term struct {
 
 // Region is region-price info of a given instance
 type Region struct {
-	Name     string  `json:"name"`
+	Code     string  `json:"code"`
 	TermList []*Term `json:"termList"`
 }
 
@@ -125,10 +125,10 @@ func convertAWS(offerList []*client.Offer) ([]*DBInstance, error) {
 
 		// fill in the term info of the instance
 		dbInstance := dbInstanceMap[instance.Type]
-		for _, regionName := range offer.RegionList {
+		for _, regionCode := range offer.RegionList {
 			isRegionExist := false
 			for _, region := range dbInstance.RegionList {
-				if region.Name == regionName {
+				if region.Code == regionCode {
 					isRegionExist = true
 					if _, ok := termMap[offer.ID]; ok {
 						region.TermList = append(region.TermList, termMap[offer.ID]...)
@@ -137,7 +137,7 @@ func convertAWS(offerList []*client.Offer) ([]*DBInstance, error) {
 			}
 			if !isRegionExist {
 				dbInstance.RegionList = append(dbInstance.RegionList, &Region{
-					Name:     regionName,
+					Code:     regionCode,
 					TermList: termMap[offer.ID],
 				})
 			}


### PR DESCRIPTION
Before, we store the region name (e.g. `N. Virginia`) in the persistent file. 
After, a map is used to map the code to the relevant region name in the frontend (e.g. `us-east-1` -->`N. Virginia`).

Also, storing the actual region code is more favorable for the code is needed for API call to the provider, leaving more space for further development. (say, redirect to the actual purchase page in a single click of the instance item).