### PR TITLE
feat: improve SEO and branding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="Description"
-      content="The Ultimate AWS RDS Instance Pricing Comparison Sheet"
+      content="The Ultimate AWS RDS and GCP Cloud SQL Instance Pricing Comparison Sheet"
     />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="Description"
-      content="The Ultimate AWS RDS and GCP Cloud SQL Instance Pricing Comparison Sheet"
+      content="The Ultimate AWS RDS and Google Cloud SQL Database Pricing Comparison Sheet"
     />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/src/components/TheFooter.vue
+++ b/frontend/src/components/TheFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <footer
     class="pt-4 mx-2 space-y-2 border-t border-gray-200 md:flex md:items-center md:justify-between md:space-y-0"
   >
     <div>
@@ -32,7 +32,7 @@
         >
       </span>
     </div>
-  </div>
+  </footer>
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/components/TheFooter.vue
+++ b/frontend/src/components/TheFooter.vue
@@ -4,33 +4,33 @@
   >
     <div>
       <div class="flex items-center justify-center space-x-1">
-        <span>DB Cost -</span>
-        <h2>The ultimate cloud database pricing sheet for AWS RDS</h2>
-      </div>
-      <div class="flex items-center md:justify-start justify-center space-x-1">
-        <a
-          class="text-blue-500 hover:text-blue-800"
-          href="https://star-history.com"
-          >Star History</a
-        >
-        <h2>- The missing GitHub star history graph</h2>
+        <h2>
+          The ultimate cloud database pricing sheet for AWS RDS and Google Cloud
+          SQL
+        </h2>
       </div>
     </div>
 
-    <div class="flex flex-row justify-center items-center space-x-2">
-      <a
-        class="text-blue-500 hover:text-blue-800"
-        href="https://github.com/bytebase/dbcost"
-        target="_blank"
-      >
-        Send us a Pull Request
+    <div
+      class="text-sm leading-8 flex flex-row flex-wrap justify-center items-center underline text-blue-700 hover:opacity-80"
+    >
+      <a href="https://star-history.com" target="_blank">
+        GitHub Star History
       </a>
-      <a
-        class="twitter-follow-button"
-        href="https://twitter.com/Bytebase"
-        data-show-count="false"
-      >
-      </a>
+    </div>
+
+    <div
+      class="text-sm leading-8 flex flex-row flex-nowrap justify-center items-center"
+    >
+      <span class="text-gray-600">
+        Sponsored by
+        <a
+          class="text-blue-500 font-bold hover:opacity-80"
+          href="https://bytebase.com"
+          target="_blank"
+          >Bytebase</a
+        >
+      </span>
     </div>
   </div>
 </template>

--- a/frontend/src/components/TheHeader.vue
+++ b/frontend/src/components/TheHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-2 flex justify-between items-center bg-slate-800 text-white">
+  <header class="p-2 flex justify-between items-center bg-slate-800 text-white">
     <div class="inline-flex flex-row items-center">
       <a href="https://dbcost.com" target="_blank">
         <img
@@ -50,7 +50,7 @@
         </n-tooltip>
       </div>
     </div>
-  </div>
+  </header>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/TheHeader.vue
+++ b/frontend/src/components/TheHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-2 items-center bg-slate-800 text-white">
+  <div class="p-2 flex justify-between items-center bg-slate-800 text-white">
     <div class="inline-flex flex-row items-center">
       <a href="https://dbcost.com" target="_blank">
         <img
@@ -10,7 +10,11 @@
       </a>
     </div>
 
-    <div class="mt-1.5 inline-flex float-right items-center space-x-2">
+    <div class="inline-flex flex-row items-center text-3xl">
+      ☁️&nbsp;&nbsp💸&nbsp;&nbsp;☁️&nbsp;&nbsp;💸&nbsp;&nbsp☁️
+    </div>
+
+    <div class="inline-flex float-right items-center space-x-2">
       <div v-is="'script'" async src="https://buttons.github.io/buttons.js" />
       <div class="mt-1">
         <a

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -2,18 +2,7 @@
   <h1
     class="flex flex-row justify-center mx-5 mt-4 text-4xl text-center text-slate-800 space-x-2"
   >
-    <span>💸</span>
-    <span
-      >The Ultimate
-      <a
-        class="text-blue-600 underline"
-        href="https://aws.amazon.com/rds"
-        target="_blank"
-        >AWS RDS</a
-      >
-      Instance Pricing Sheet</span
-    >
-    <span>💸</span>
+    The Ultimate AWS RDS and Google Cloud SQL Database Pricing Sheet
   </h1>
 
   <!-- menu -->


### PR DESCRIPTION
1. Add GCP to the keyword
2. Use naked h1 for the slogan to avoid confusing the search engine
3. Cleanup footer to only highlight the db cost its own slogan
4. Add cloud and money emoji to the header