### PR TITLE
feat:  identifier for each col of the data table

### DIFF
--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -88,12 +88,12 @@ type priceDimensionRaw struct {
 
 // priceRaw is the raw price struct marshaled from the aws json file
 type priceRaw struct {
-	OfferTermCode string                       `json:"offerTermCode"`
-	Dimension     map[string]priceDimensionRaw `json:"priceDimensions"`
-	Term          *client.ChargePayload        `json:"termAttributes"`
+	Dimension map[string]priceDimensionRaw `json:"priceDimensions"`
+	Term      *client.ChargePayload        `json:"termAttributes"`
 }
 
 // InfoEndPoint is the instance info endpoint
+// More infomation, see: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/reading-an-offer.html
 const InfoEndPoint = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonRDS/current/index.json"
 
 // GetOffer returns the offers provided by AWS.
@@ -155,11 +155,13 @@ func extractOffer(rawData *pricing) ([]*client.Offer, error) {
 	for chargeType, instanceOfferList := range rawEntry {
 		// we use skuID here to track the instance relevant to this offer
 		for instanceSKU, _offerList := range instanceOfferList {
-			for _, rawOffer := range _offerList {
+			for instanceTermCode, rawOffer := range _offerList {
 				offer := &client.Offer{
-					ID:       incrID,
-					SKU:      instanceSKU,
-					TermCode: rawOffer.OfferTermCode,
+					ID: incrID,
+					// e.g. 9QH3PUGXCYKNCYPB
+					SKU: instanceSKU,
+					// e.g. 9QH3PUGXCYKNCYPB.HU7G6KETJZ
+					TermCode: instanceTermCode,
 					// AWS only offer instance-wise product
 					OfferType:     client.OfferTypeInstance,
 					ChargeType:    client.ChargeType(chargeType),

--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -88,8 +88,9 @@ type priceDimensionRaw struct {
 
 // priceRaw is the raw price struct marshaled from the aws json file
 type priceRaw struct {
-	Dimension map[string]priceDimensionRaw `json:"priceDimensions"`
-	Term      *client.ChargePayload        `json:"termAttributes"`
+	OfferTermCode string                       `json:"offerTermCode"`
+	Dimension     map[string]priceDimensionRaw `json:"priceDimensions"`
+	Term          *client.ChargePayload        `json:"termAttributes"`
 }
 
 // InfoEndPoint is the instance info endpoint
@@ -156,8 +157,9 @@ func extractOffer(rawData *pricing) ([]*client.Offer, error) {
 		for instanceSKU, _offerList := range instanceOfferList {
 			for _, rawOffer := range _offerList {
 				offer := &client.Offer{
-					ID:  incrID,
-					SKU: instanceSKU,
+					ID:       incrID,
+					SKU:      instanceSKU,
+					TermCode: rawOffer.OfferTermCode,
 					// AWS only offer instance-wise product
 					OfferType:     client.OfferTypeInstance,
 					ChargeType:    client.ChargeType(chargeType),
@@ -174,6 +176,7 @@ func extractOffer(rawData *pricing) ([]*client.Offer, error) {
 					} else {
 						offer.HourlyUSD = USDFloat
 					}
+
 				}
 
 				incrID++

--- a/client/client.go
+++ b/client/client.go
@@ -74,6 +74,10 @@ type Offer struct {
 
 	// e.g. AWS: 9QH3PUGXCYKNCYPB, GCP: 0009-6F35-3126
 	SKU string
+	// The same SKU may have different charge type, the term code is used to differentiate this.
+	// e.g. Instance A may be charged monthly(with term code 'a', SKU 'A') of daily((with term code 'b', SKU 'A')).\
+	// 		AWS: 9QH3PUGXCYKNCYPB.HU7G6KETJZ
+	TermCode string
 	// Allowed OfferType are Instance, RAM, CPU
 	OfferType OfferType
 	// If the offer type is Instance, the payload would be the information of that instance, otherwise this field will be nil

--- a/client/gcp/gcp.go
+++ b/client/gcp/gcp.go
@@ -134,8 +134,10 @@ func (c *Client) GetOffer() ([]*client.Offer, error) {
 		}
 
 		offer := &client.Offer{
-			ID:        incrID,
-			SKU:       rawOffer.ID,
+			ID:  incrID,
+			SKU: rawOffer.ID,
+			// TermCode in GCP is the same as its SKU as different term is identified as different SKU.
+			TermCode:  rawOffer.ID,
 			OfferType: offerType,
 
 			// All GCP services are charged on demand literal, but we consider commitment for a length as reserved type

--- a/frontend/src/types/term.ts
+++ b/frontend/src/types/term.ts
@@ -10,7 +10,7 @@ export type TermPayload = {
 } | null;
 
 export type Term = {
-  sku: string;
+  code: string;
   databaseEngine: EngineType;
   type: ChargeType;
   payload: TermPayload;

--- a/frontend/src/views/AppView.vue
+++ b/frontend/src/views/AppView.vue
@@ -299,7 +299,7 @@ const refreshDataTable = () => {
         const key = `${dbInstance.name}-${region.code}`;
         const newRow: DataRow = {
           id: -1,
-          key: term.sku,
+          key: term.code,
           childCnt: 1,
           cloudProvider: dbInstance.cloudProvider,
           name: dbInstance.name,
@@ -344,7 +344,7 @@ const refreshDataTable = () => {
     });
 
     // filter by keyword, we only enable this when the keyword is set by user
-    const keyword = config.keyword;
+    const keyword = config.keyword.toLowerCase();
     if (keyword) {
       const filteredDataRowList: DataRow[] = dataRowList.filter((row) => {
         if (

--- a/store/db_instance.go
+++ b/store/db_instance.go
@@ -20,7 +20,7 @@ type TermPayload struct {
 
 // Term is the pricing term of a given instance
 type Term struct {
-	SKU string `json:"sku"`
+	Code string `json:"code"`
 
 	DatabaseEngine client.EngineType `json:"databaseEngine"`
 	Type           client.ChargeType `json:"type"`
@@ -75,7 +75,7 @@ func Convert(offerList []*client.Offer, cloudProvider CloudProvider) ([]*DBInsta
 		}
 
 		term := &Term{
-			SKU:            offer.SKU,
+			Code:           offer.TermCode,
 			DatabaseEngine: offer.InstancePayload.DatabaseEngine,
 			Type:           offer.ChargeType,
 			Payload:        termPayload,


### PR DESCRIPTION
In AWS, we use SKU.TermCode to identify the col.
In GCP, a SKU is bind to a specific charge type and a instance.

In short, SKU+TermCode is the PK of an offer in AWS, SKU is the PK of that in GCP.