### PR TITLE
adopt APEX's event callback to xkcdify the chart

### DIFF
--- a/frontend/src/components/ApexChart/CostLineChart.vue
+++ b/frontend/src/components/ApexChart/CostLineChart.vue
@@ -4,9 +4,8 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { onMounted, onUpdated, ref, PropType, computed } from "vue";
-import { select } from "d3-selection";
-import { addFilter } from "./utils";
+import { ref, PropType, computed } from "vue";
+import { xkcdify } from "./utils";
 import { DataRow } from "../CostTable";
 
 const props = defineProps({
@@ -45,6 +44,9 @@ const options = computed(() => {
     chart: {
       toolbar: { show: false },
       fontFamily: "xkcd",
+      events: {
+        animationEnd: xkcdify.bind(this, chartDom.value as HTMLElement),
+      },
     },
     xaxis: {
       categories: xGrid,
@@ -101,24 +103,5 @@ const series = computed(() => {
   }
 
   return res;
-});
-
-const installFilter = () => {
-  const filter = "url(#xkcdify)";
-  const d3Selection = select(chartDom.value as any).select("svg") as any;
-
-  addFilter(d3Selection);
-  d3Selection.selectAll("line").attr("filter", filter);
-  d3Selection.selectAll("path").attr("filter", filter);
-  d3Selection.selectAll("#apexcharts-grid").attr("filter", filter);
-  d3Selection.selectAll("#apexcharts-series").attr("filter", filter);
-};
-
-onMounted(() => {
-  installFilter();
-});
-
-onUpdated(() => {
-  installFilter();
 });
 </script>

--- a/frontend/src/components/ApexChart/utils/index.ts
+++ b/frontend/src/components/ApexChart/utils/index.ts
@@ -1,3 +1,3 @@
-import addFilter from "./addFilter";
+import { xkcdify } from "./xkcdify";
 
-export { addFilter };
+export { xkcdify };

--- a/frontend/src/components/ApexChart/utils/xkcdify.ts
+++ b/frontend/src/components/ApexChart/utils/xkcdify.ts
@@ -1,6 +1,7 @@
 import { D3Selection } from "../types";
+import { select } from "d3-selection";
 
-export default (selection: D3Selection) => {
+const addFilter = (selection: D3Selection) => {
   selection
     .append("defs")
     .append("filter")
@@ -20,6 +21,13 @@ export default (selection: D3Selection) => {
     });
 };
 
-export const a = (selection: D3Selection) => {
-  selection.select("filter").remove();
+export const xkcdify = (chartDom: HTMLElement) => {
+  const d3Selection = select(chartDom as any).select("svg") as any;
+
+  addFilter(d3Selection);
+  const filter = "url(#xkcdify)";
+  d3Selection.selectAll("line").attr("filter", filter);
+  d3Selection.selectAll("path").attr("filter", filter);
+  d3Selection.selectAll("#apexcharts-grid").attr("filter", filter);
+  d3Selection.selectAll("#apexcharts-series").attr("filter", filter);
 };


### PR DESCRIPTION
Use the hook provided by Apex to xkcdify the chart.

The current way of doing this will actually xkcdify each frame of the animation, causing an unacceptable pause after user selects a row.
After this PR, the xkcdify process will be only applied once. With that being said, each refresh of the chart ( say, a new row is checked) will cause a short time of inconsistancy in the style.
This process can be descriped as follow:
1. New data added
2. Render a new SVG ( filter added is removed )3. (Normal style)
3. Play animation. (Normal style)
4. xkcdify the final SVG. (xkcd style)

Another possible solution is turnning off the animation. The SVG rendered will be xkcdify instantly.