### PR TITLE
chore: next link pass href to anchor tags

### DIFF
--- a/frontend/components/ButtonGroup.tsx
+++ b/frontend/components/ButtonGroup.tsx
@@ -16,8 +16,10 @@ const ButtonGroup: React.FC<Props> = ({ type }) => {
           Reset
         </Button>
       ) : (
-        <Link href="/">
-          <Button className="mr-2">Back to Dashboard</Button>
+        <Link href="/" passHref>
+          <a>
+            <Button className="mr-2">Back to Dashboard</Button>
+          </a>
         </Link>
       )}
       <Button>Copy URL</Button>

--- a/frontend/components/CompareTable.tsx
+++ b/frontend/components/CompareTable.tsx
@@ -294,7 +294,9 @@ const CompareTable: React.FC<Props> = ({
                           />
                         </div>
                       )}
-                      <Link href={`/instance/${name}`}>{name}</Link>
+                      <Link href={`/instance/${name}`} passHref>
+                        <a>{name}</a>
+                      </Link>
                     </div>
                   );
                 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -17,29 +17,33 @@ const Header: React.FC = () => {
     <header className="flex justify-center bg-slate-800">
       <div className="w-full 2xl:w-5/6 2xl:max-w-7xl flex justify-between items-center flex-grow-0 p-2 text-white">
         <div className="inline-flex flex-row items-center gap-4">
-          <Link href="/">
-            <div
-              className="relative w-32 h-8 cursor-pointer"
-              onClick={() => void resetSearchConfig()}
-            >
-              <Image
-                src="/icons/dbcost-logo-full.webp"
-                alt="DB Cost"
-                layout="fill"
-                objectFit="contain"
-              />
-            </div>
-          </Link>
-          {providerList.map((provider: string) => (
-            <Link href={`/provider/${provider}`} key={provider}>
-              <span
-                className={`${
-                  providerInRoute === provider ? "border-b" : ""
-                } h-8 text-lg pt-0.5 text-white cursor-pointer`}
+          <Link href="/" passHref>
+            <a>
+              <div
+                className="relative w-32 h-8 cursor-pointer"
                 onClick={() => void resetSearchConfig()}
               >
-                {provider.toUpperCase()}
-              </span>
+                <Image
+                  src="/icons/dbcost-logo-full.webp"
+                  alt="DB Cost"
+                  layout="fill"
+                  objectFit="contain"
+                />
+              </div>
+            </a>
+          </Link>
+          {providerList.map((provider: string) => (
+            <Link href={`/provider/${provider}`} key={provider} passHref>
+              <a>
+                <span
+                  className={`${
+                    providerInRoute === provider ? "border-b" : ""
+                  } h-8 text-lg pt-0.5 text-white cursor-pointer`}
+                  onClick={() => void resetSearchConfig()}
+                >
+                  {provider.toUpperCase()}
+                </span>
+              </a>
             </Link>
           ))}
         </div>

--- a/frontend/components/RelatedTable.tsx
+++ b/frontend/components/RelatedTable.tsx
@@ -19,7 +19,9 @@ const RelatedTable: React.FC<Props> = ({ title, instance, dataSource }) => {
         name === instance ? (
           name
         ) : (
-          <Link href={`/instance/${name}`}>{name}</Link>
+          <Link href={`/instance/${name}`} passHref>
+            <a>{name}</a>
+          </Link>
         ),
     },
     {


### PR DESCRIPTION
Pass the `href` attribute from `next/link` to `<a>` tags so that the build result will contain usable links without needing to enable JavaScript. This can greatly improve the site's accessibility and SEO.

Here's a comparison of build results before and after the change.
| Before | After |
| :--: | :--: |
| ![Shot-2022-10-20-Microsoft Edge-6gofsGZk](https://user-images.githubusercontent.com/56376387/196850048-f27a747c-1ed3-4222-973b-eb469e4f3146.png) | ![Shot-2022-10-20-Microsoft Edge-qmx3ASco](https://user-images.githubusercontent.com/56376387/196850053-9421f574-97be-4262-ae5f-df81a1c1fc9f.png) |
| Doesn't include `<a>` links. | Includes `<a>` links. |

