### PR TITLE
feat: support Static Site Generation

### DIFF
--- a/frontend/components/CompareTable.tsx
+++ b/frontend/components/CompareTable.tsx
@@ -10,7 +10,7 @@ import {
 import Link from "next/link";
 import { Table } from "antd";
 import { isEqual } from "lodash";
-import { DataSource, TableType } from "@/types";
+import { DataSource, TableType, tablePaginationConfig } from "@/types";
 import {
   getDiff,
   getDigit,
@@ -45,8 +45,6 @@ enum SorterColumn {
   MEMORY = "memory",
   EXPECTED_COST = "expectedCost",
 }
-
-const tablePaginationConfig = { defaultPageSize: 50, hideOnSinglePage: true };
 
 const CompareTable: React.FC<Props> = ({
   type = TableType.DASHBOARD,

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { NextPage } from "next";
+import type { NextPage, GetStaticProps } from "next";
 import MainLayout from "@/layouts/main";
 import ButtonGroup from "@/components/ButtonGroup";
 import RegionMenu from "@/components/RegionMenu";
@@ -7,162 +7,182 @@ import SearchMenu from "@/components/SearchMenu";
 import CompareTable from "@/components/CompareTable";
 import { useDBInstanceContext, useSearchConfigContext } from "@/stores";
 import { getPrice, getRegionCode, getRegionName } from "@/utils";
-import { DataSource } from "@/types";
+import {
+  DataSource,
+  DBInstance,
+  SearchConfig,
+  SearchConfigDefault,
+  tablePaginationConfig,
+} from "@/types";
 
-const Home: NextPage = () => {
-  const [dataSource, setDataSource] = useState<DataSource[]>([]);
+interface Props {
+  serverSideCompareTableData: DataSource[];
+}
+
+const generateTableData = (
+  dbInstanceList: DBInstance[],
+  searchConfig: SearchConfig
+): DataSource[] => {
+  let rowCount = 0;
+  const dataSource: DataSource[] = [];
+  const {
+    cloudProvider,
+    region,
+    engineType,
+    chargeType,
+    minCPU,
+    minRAM,
+    utilization,
+    leaseLength,
+    keyword,
+  } = searchConfig;
+
+  // If any of these three below is empty, display no table row.
+  if (
+    region.length === 0 ||
+    engineType.length === 0 ||
+    chargeType.length === 0
+  ) {
+    return [];
+  }
+
+  const cloudProviderSet = new Set(cloudProvider);
+  const selectedRegionCodeSet = new Set(
+    region.map((region) => getRegionCode(region)).flat()
+  );
+  const engineSet = new Set(engineType);
+  const chargeTypeSet = new Set(chargeType);
+
+  // Process each db instance.
+  dbInstanceList.forEach((dbInstance) => {
+    if (
+      (minRAM !== undefined && Number(dbInstance.memory) < minRAM) ||
+      (minCPU !== undefined && Number(dbInstance.cpu) < minCPU)
+    ) {
+      return;
+    }
+
+    if (!cloudProviderSet.has(dbInstance.cloudProvider)) {
+      return;
+    }
+
+    const selectedRegionList = dbInstance.regionList.filter((region) =>
+      selectedRegionCodeSet.has(region.code)
+    );
+
+    if (selectedRegionList.length === 0) {
+      return;
+    }
+
+    const dataRowList: DataSource[] = [];
+    const dataRowMap: Map<string, DataSource[]> = new Map();
+
+    selectedRegionList.forEach((region) => {
+      const selectedTermList = region.termList.filter(
+        (term) =>
+          chargeTypeSet.has(term.type) && engineSet.has(term.databaseEngine)
+      );
+
+      let basePriceMap = new Map<string, number>();
+      selectedTermList.forEach((term) => {
+        if (term.type === "OnDemand") {
+          basePriceMap.set(term.databaseEngine, term.hourlyUSD);
+        }
+      });
+
+      const regionName = getRegionName(region.code);
+      selectedTermList.forEach((term) => {
+        const regionInstanceKey = `${dbInstance.name}::${region.code}::${term.databaseEngine}`;
+        const newRow: DataSource = {
+          // set this later
+          id: -1,
+          // We use :: for separation because AWS use . and GCP use - as separator.
+          key: `${dbInstance.name}::${region.code}::${term.code}`,
+          // set this later
+          childCnt: 0,
+          cloudProvider: dbInstance.cloudProvider,
+          name: dbInstance.name,
+          processor: dbInstance.processor,
+          cpu: dbInstance.cpu,
+          memory: dbInstance.memory,
+          engineType: term.databaseEngine,
+          commitment: { usd: term.commitmentUSD },
+          hourly: { usd: term.hourlyUSD },
+          leaseLength: term.payload?.leaseContractLength ?? "N/A",
+          // We store the region code for each provider, and show the user the actual region information.
+          // e.g. AWS's us-east-1 and GCP's us-east-4 are refer to the same region (N. Virginia)
+          region: regionName,
+          baseHourly: basePriceMap.get(term.databaseEngine) as number,
+          // set this later
+          expectedCost: 0,
+        };
+        newRow.expectedCost = getPrice(newRow, utilization, leaseLength);
+
+        if (dataRowMap.has(regionInstanceKey)) {
+          const existedDataRowList = dataRowMap.get(
+            regionInstanceKey
+          ) as DataSource[];
+          newRow.id = existedDataRowList[0].id;
+          existedDataRowList.push(newRow);
+        } else {
+          rowCount++;
+          newRow.id = rowCount;
+          dataRowMap.set(regionInstanceKey, [newRow]);
+        }
+      });
+    });
+
+    dataRowMap.forEach((rows) => {
+      rows.sort((a, b) => {
+        // Sort rows according to the following criterion:
+        // 1. On demand price goes first.
+        // 2. Sort on expected cost in ascending order.
+        if (a.leaseLength === "N/A") {
+          return -1;
+        } else if (b.leaseLength === "N/A") {
+          return 1;
+        }
+
+        return a.expectedCost - b.expectedCost;
+      });
+      rows.forEach((row) => {
+        row.childCnt = rows.length;
+      });
+      dataRowList.push(...rows);
+    });
+
+    const searchKey = keyword?.toLowerCase();
+    if (searchKey) {
+      // filter by keyword
+      const filteredDataRowList: DataSource[] = dataRowList.filter(
+        (row) =>
+          row.name.toLowerCase().includes(searchKey) ||
+          row.memory.toLowerCase().includes(searchKey) ||
+          row.processor.toLowerCase().includes(searchKey) ||
+          row.region.toLowerCase().includes(searchKey)
+      );
+      dataSource.push(...filteredDataRowList);
+      return;
+    }
+
+    dataSource.push(...dataRowList);
+  });
+
+  return dataSource;
+};
+
+const Home: NextPage<Props> = ({ serverSideCompareTableData }) => {
+  const [dataSource, setDataSource] = useState<DataSource[]>(
+    serverSideCompareTableData
+  );
   const { dbInstanceList, loadDBInstanceList, getAvailableRegionList } =
     useDBInstanceContext();
   const { searchConfig } = useSearchConfigContext();
 
-  const generateTableData = useCallback((): DataSource[] => {
-    let rowCount = 0;
-    const dataSource: DataSource[] = [];
-    const {
-      cloudProvider,
-      region,
-      engineType,
-      chargeType,
-      minCPU,
-      minRAM,
-      utilization,
-      leaseLength,
-      keyword,
-    } = searchConfig;
-
-    // If any of these three below is empty, display no table row.
-    if (
-      region.length === 0 ||
-      engineType.length === 0 ||
-      chargeType.length === 0
-    ) {
-      return [];
-    }
-
-    const cloudProviderSet = new Set(cloudProvider);
-    const selectedRegionCodeSet = new Set(
-      region.map((region) => getRegionCode(region)).flat()
-    );
-    const engineSet = new Set(engineType);
-    const chargeTypeSet = new Set(chargeType);
-
-    // Process each db instance.
-    dbInstanceList.forEach((dbInstance) => {
-      if (
-        (minRAM !== undefined && Number(dbInstance.memory) < minRAM) ||
-        (minCPU !== undefined && Number(dbInstance.cpu) < minCPU)
-      ) {
-        return;
-      }
-
-      if (!cloudProviderSet.has(dbInstance.cloudProvider)) {
-        return;
-      }
-
-      const selectedRegionList = dbInstance.regionList.filter((region) =>
-        selectedRegionCodeSet.has(region.code)
-      );
-
-      if (selectedRegionList.length === 0) {
-        return;
-      }
-
-      const dataRowList: DataSource[] = [];
-      const dataRowMap: Map<string, DataSource[]> = new Map();
-
-      selectedRegionList.forEach((region) => {
-        const selectedTermList = region.termList.filter(
-          (term) =>
-            chargeTypeSet.has(term.type) && engineSet.has(term.databaseEngine)
-        );
-
-        let basePriceMap = new Map<string, number>();
-        selectedTermList.forEach((term) => {
-          if (term.type === "OnDemand") {
-            basePriceMap.set(term.databaseEngine, term.hourlyUSD);
-          }
-        });
-
-        const regionName = getRegionName(region.code);
-        selectedTermList.forEach((term) => {
-          const regionInstanceKey = `${dbInstance.name}::${region.code}::${term.databaseEngine}`;
-          const newRow: DataSource = {
-            // set this later
-            id: -1,
-            // We use :: for separation because AWS use . and GCP use - as separator.
-            key: `${dbInstance.name}::${region.code}::${term.code}`,
-            // set this later
-            childCnt: 0,
-            cloudProvider: dbInstance.cloudProvider,
-            name: dbInstance.name,
-            processor: dbInstance.processor,
-            cpu: dbInstance.cpu,
-            memory: dbInstance.memory,
-            engineType: term.databaseEngine,
-            commitment: { usd: term.commitmentUSD },
-            hourly: { usd: term.hourlyUSD },
-            leaseLength: term.payload?.leaseContractLength ?? "N/A",
-            // We store the region code for each provider, and show the user the actual region information.
-            // e.g. AWS's us-east-1 and GCP's us-east-4 are refer to the same region (N. Virginia)
-            region: regionName,
-            baseHourly: basePriceMap.get(term.databaseEngine) as number,
-            // set this later
-            expectedCost: 0,
-          };
-          newRow.expectedCost = getPrice(newRow, utilization, leaseLength);
-
-          if (dataRowMap.has(regionInstanceKey)) {
-            const existedDataRowList = dataRowMap.get(
-              regionInstanceKey
-            ) as DataSource[];
-            newRow.id = existedDataRowList[0].id;
-            existedDataRowList.push(newRow);
-          } else {
-            rowCount++;
-            newRow.id = rowCount;
-            dataRowMap.set(regionInstanceKey, [newRow]);
-          }
-        });
-      });
-
-      dataRowMap.forEach((rows) => {
-        rows.sort((a, b) => {
-          // Sort rows according to the following criterion:
-          // 1. On demand price goes first.
-          // 2. Sort on expected cost in ascending order.
-          if (a.leaseLength === "N/A") {
-            return -1;
-          } else if (b.leaseLength === "N/A") {
-            return 1;
-          }
-
-          return a.expectedCost - b.expectedCost;
-        });
-        rows.forEach((row) => {
-          row.childCnt = rows.length;
-        });
-        dataRowList.push(...rows);
-      });
-
-      const searchKey = keyword?.toLowerCase();
-      if (searchKey) {
-        // filter by keyword
-        const filteredDataRowList: DataSource[] = dataRowList.filter(
-          (row) =>
-            row.name.toLowerCase().includes(searchKey) ||
-            row.memory.toLowerCase().includes(searchKey) ||
-            row.processor.toLowerCase().includes(searchKey) ||
-            row.region.toLowerCase().includes(searchKey)
-        );
-        dataSource.push(...filteredDataRowList);
-        return;
-      }
-
-      dataSource.push(...dataRowList);
-    });
-
-    return dataSource;
-  }, [dbInstanceList, searchConfig]);
+  const memoizedGenerate = useCallback(
+    (): DataSource[] => generateTableData(dbInstanceList, searchConfig),
+    [dbInstanceList, searchConfig]
+  );
 
   useEffect(() => {
     loadDBInstanceList();
@@ -179,7 +199,7 @@ const Home: NextPage = () => {
         <CompareTable
           dataSource={dataSource}
           setDataSource={setDataSource}
-          generateTableData={generateTableData}
+          generateTableData={memoizedGenerate}
         />
       </div>
     </MainLayout>
@@ -187,3 +207,22 @@ const Home: NextPage = () => {
 };
 
 export default Home;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const sourceFileName = "dbInstance.json";
+  const data = (await import(`../../data/${sourceFileName}`))
+    .default as DBInstance[];
+  // For SEO, showing the first page is enough. So we only need to
+  // pass the first page of data to the page. Passing the whole large
+  // `data` will make this page twice as large to reduce performance.
+  const firstPageData = data.slice(0, tablePaginationConfig.defaultPageSize);
+
+  return {
+    props: {
+      serverSideCompareTableData: generateTableData(
+        firstPageData,
+        SearchConfigDefault
+      ),
+    },
+  };
+};

--- a/frontend/pages/provider/[provider].tsx
+++ b/frontend/pages/provider/[provider].tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { NextPage } from "next";
-import { useRouter } from "next/router";
+import type { NextPage, GetStaticProps } from "next";
 import MainLayout from "@/layouts/main";
 import ButtonGroup from "@/components/ButtonGroup";
 import RegionMenu from "@/components/RegionMenu";
@@ -8,164 +7,188 @@ import SearchMenu from "@/components/SearchMenu";
 import CompareTable from "@/components/CompareTable";
 import { useDBInstanceContext, useSearchConfigContext } from "@/stores";
 import { getPrice, getRegionCode, getRegionName } from "@/utils";
-import type { DataSource, CloudProvider } from "@/types";
+import {
+  DataSource,
+  CloudProvider,
+  DBInstance,
+  SearchConfig,
+  tablePaginationConfig,
+  SearchConfigDefault,
+} from "@/types";
 
-const Provider: NextPage = () => {
-  const [dataSource, setDataSource] = useState<DataSource[]>([]);
-  const router = useRouter();
-  const { provider } = router.query;
+interface Params {
+  provider: string;
+}
+
+interface Props {
+  serverSideCompareTableData: DataSource[];
+  name: string;
+}
+
+const generateTableData = (
+  dbInstanceList: DBInstance[],
+  searchConfig: SearchConfig
+): DataSource[] => {
+  let rowCount = 0;
+  const dataSource: DataSource[] = [];
+  const {
+    cloudProvider,
+    region,
+    engineType,
+    chargeType,
+    minCPU,
+    minRAM,
+    utilization,
+    leaseLength,
+    keyword,
+  } = searchConfig;
+
+  // If any of these three below is empty, display no table row.
+  if (
+    region.length === 0 ||
+    engineType.length === 0 ||
+    chargeType.length === 0
+  ) {
+    return [];
+  }
+
+  const cloudProviderSet = new Set(cloudProvider);
+  const selectedRegionCodeSet = new Set(
+    region.map((region) => getRegionCode(region)).flat()
+  );
+  const engineSet = new Set(engineType);
+  const chargeTypeSet = new Set(chargeType);
+
+  // Process each db instance.
+  dbInstanceList.forEach((dbInstance) => {
+    if (
+      (minRAM !== undefined && Number(dbInstance.memory) < minRAM) ||
+      (minCPU !== undefined && Number(dbInstance.cpu) < minCPU)
+    ) {
+      return;
+    }
+
+    if (!cloudProviderSet.has(dbInstance.cloudProvider)) {
+      return;
+    }
+
+    const selectedRegionList = dbInstance.regionList.filter((region) =>
+      selectedRegionCodeSet.has(region.code)
+    );
+
+    if (selectedRegionList.length === 0) {
+      return;
+    }
+
+    const dataRowList: DataSource[] = [];
+    const dataRowMap: Map<string, DataSource[]> = new Map();
+
+    selectedRegionList.forEach((region) => {
+      const selectedTermList = region.termList.filter(
+        (term) =>
+          chargeTypeSet.has(term.type) && engineSet.has(term.databaseEngine)
+      );
+
+      let basePriceMap = new Map<string, number>();
+      selectedTermList.forEach((term) => {
+        if (term.type === "OnDemand") {
+          basePriceMap.set(term.databaseEngine, term.hourlyUSD);
+        }
+      });
+
+      const regionName = getRegionName(region.code);
+      selectedTermList.forEach((term) => {
+        const regionInstanceKey = `${dbInstance.name}::${region.code}::${term.databaseEngine}`;
+        const newRow: DataSource = {
+          // set this later
+          id: -1,
+          // We use :: for separation because AWS use . and GCP use - as separator.
+          key: `${dbInstance.name}::${region.code}::${term.code}`,
+          // set this later
+          childCnt: 0,
+          cloudProvider: dbInstance.cloudProvider,
+          name: dbInstance.name,
+          processor: dbInstance.processor,
+          cpu: dbInstance.cpu,
+          memory: dbInstance.memory,
+          engineType: term.databaseEngine,
+          commitment: { usd: term.commitmentUSD },
+          hourly: { usd: term.hourlyUSD },
+          leaseLength: term.payload?.leaseContractLength ?? "N/A",
+          // We store the region code for each provider, and show the user the actual region information.
+          // e.g. AWS's us-east-1 and GCP's us-east-4 are refer to the same region (N. Virginia)
+          region: regionName,
+          baseHourly: basePriceMap.get(term.databaseEngine) as number,
+          // set this later
+          expectedCost: 0,
+        };
+        newRow.expectedCost = getPrice(newRow, utilization, leaseLength);
+
+        if (dataRowMap.has(regionInstanceKey)) {
+          const existedDataRowList = dataRowMap.get(
+            regionInstanceKey
+          ) as DataSource[];
+          newRow.id = existedDataRowList[0].id;
+          existedDataRowList.push(newRow);
+        } else {
+          rowCount++;
+          newRow.id = rowCount;
+          dataRowMap.set(regionInstanceKey, [newRow]);
+        }
+      });
+    });
+
+    dataRowMap.forEach((rows) => {
+      rows.sort((a, b) => {
+        // Sort rows according to the following criterion:
+        // 1. On demand price goes first.
+        // 2. Sort on expected cost in ascending order.
+        if (a.leaseLength === "N/A") {
+          return -1;
+        } else if (b.leaseLength === "N/A") {
+          return 1;
+        }
+
+        return a.expectedCost - b.expectedCost;
+      });
+      rows.forEach((row) => {
+        row.childCnt = rows.length;
+      });
+      dataRowList.push(...rows);
+    });
+
+    const searchKey = keyword?.toLowerCase();
+    if (searchKey) {
+      // filter by keyword
+      const filteredDataRowList: DataSource[] = dataRowList.filter(
+        (row) =>
+          row.name.toLowerCase().includes(searchKey) ||
+          row.memory.toLowerCase().includes(searchKey) ||
+          row.processor.toLowerCase().includes(searchKey) ||
+          row.region.toLowerCase().includes(searchKey)
+      );
+      dataSource.push(...filteredDataRowList);
+      return;
+    }
+
+    dataSource.push(...dataRowList);
+  });
+
+  return dataSource;
+};
+
+const Provider: NextPage<Props> = ({ serverSideCompareTableData, name }) => {
+  const [dataSource, setDataSource] = useState<DataSource[]>(
+    serverSideCompareTableData
+  );
   const { dbInstanceList, loadDBInstanceList, getAvailableRegionList } =
     useDBInstanceContext();
   const { searchConfig, update: updateSearchConfig } = useSearchConfigContext();
 
-  const generateTableData = useCallback((): DataSource[] => {
-    let rowCount = 0;
-    const dataSource: DataSource[] = [];
-    const {
-      cloudProvider,
-      region,
-      engineType,
-      chargeType,
-      minCPU,
-      minRAM,
-      utilization,
-      leaseLength,
-      keyword,
-    } = searchConfig;
-
-    // If any of these three below is empty, display no table row.
-    if (
-      region.length === 0 ||
-      engineType.length === 0 ||
-      chargeType.length === 0
-    ) {
-      return [];
-    }
-
-    const cloudProviderSet = new Set(cloudProvider);
-    const selectedRegionCodeSet = new Set(
-      region.map((region) => getRegionCode(region)).flat()
-    );
-    const engineSet = new Set(engineType);
-    const chargeTypeSet = new Set(chargeType);
-
-    // Process each db instance.
-    dbInstanceList.forEach((dbInstance) => {
-      if (
-        (minRAM !== undefined && Number(dbInstance.memory) < minRAM) ||
-        (minCPU !== undefined && Number(dbInstance.cpu) < minCPU)
-      ) {
-        return;
-      }
-
-      if (!cloudProviderSet.has(dbInstance.cloudProvider)) {
-        return;
-      }
-
-      const selectedRegionList = dbInstance.regionList.filter((region) =>
-        selectedRegionCodeSet.has(region.code)
-      );
-
-      if (selectedRegionList.length === 0) {
-        return;
-      }
-
-      const dataRowList: DataSource[] = [];
-      const dataRowMap: Map<string, DataSource[]> = new Map();
-
-      selectedRegionList.forEach((region) => {
-        const selectedTermList = region.termList.filter(
-          (term) =>
-            chargeTypeSet.has(term.type) && engineSet.has(term.databaseEngine)
-        );
-
-        let basePriceMap = new Map<string, number>();
-        selectedTermList.forEach((term) => {
-          if (term.type === "OnDemand") {
-            basePriceMap.set(term.databaseEngine, term.hourlyUSD);
-          }
-        });
-
-        const regionName = getRegionName(region.code);
-        selectedTermList.forEach((term) => {
-          const regionInstanceKey = `${dbInstance.name}::${region.code}::${term.databaseEngine}`;
-          const newRow: DataSource = {
-            // set this later
-            id: -1,
-            // We use :: for separation because AWS use . and GCP use - as separator.
-            key: `${dbInstance.name}::${region.code}::${term.code}`,
-            // set this later
-            childCnt: 0,
-            cloudProvider: dbInstance.cloudProvider,
-            name: dbInstance.name,
-            processor: dbInstance.processor,
-            cpu: dbInstance.cpu,
-            memory: dbInstance.memory,
-            engineType: term.databaseEngine,
-            commitment: { usd: term.commitmentUSD },
-            hourly: { usd: term.hourlyUSD },
-            leaseLength: term.payload?.leaseContractLength ?? "N/A",
-            // We store the region code for each provider, and show the user the actual region information.
-            // e.g. AWS's us-east-1 and GCP's us-east-4 are refer to the same region (N. Virginia)
-            region: regionName,
-            baseHourly: basePriceMap.get(term.databaseEngine) as number,
-            // set this later
-            expectedCost: 0,
-          };
-          newRow.expectedCost = getPrice(newRow, utilization, leaseLength);
-
-          if (dataRowMap.has(regionInstanceKey)) {
-            const existedDataRowList = dataRowMap.get(
-              regionInstanceKey
-            ) as DataSource[];
-            newRow.id = existedDataRowList[0].id;
-            existedDataRowList.push(newRow);
-          } else {
-            rowCount++;
-            newRow.id = rowCount;
-            dataRowMap.set(regionInstanceKey, [newRow]);
-          }
-        });
-      });
-
-      dataRowMap.forEach((rows) => {
-        rows.sort((a, b) => {
-          // Sort rows according to the following criterion:
-          // 1. On demand price goes first.
-          // 2. Sort on expected cost in ascending order.
-          if (a.leaseLength === "N/A") {
-            return -1;
-          } else if (b.leaseLength === "N/A") {
-            return 1;
-          }
-
-          return a.expectedCost - b.expectedCost;
-        });
-        rows.forEach((row) => {
-          row.childCnt = rows.length;
-        });
-        dataRowList.push(...rows);
-      });
-
-      const searchKey = keyword?.toLowerCase();
-      if (searchKey) {
-        // filter by keyword
-        const filteredDataRowList: DataSource[] = dataRowList.filter(
-          (row) =>
-            row.name.toLowerCase().includes(searchKey) ||
-            row.memory.toLowerCase().includes(searchKey) ||
-            row.processor.toLowerCase().includes(searchKey) ||
-            row.region.toLowerCase().includes(searchKey)
-        );
-        dataSource.push(...filteredDataRowList);
-        return;
-      }
-
-      dataSource.push(...dataRowList);
-    });
-
-    return dataSource;
-  }, [dbInstanceList, searchConfig]);
+  const memoizedGenerate = useCallback(
+    (): DataSource[] => generateTableData(dbInstanceList, searchConfig),
+    [dbInstanceList, searchConfig]
+  );
 
   useEffect(() => {
     loadDBInstanceList();
@@ -174,16 +197,16 @@ const Provider: NextPage = () => {
   const availableRegionList = getAvailableRegionList();
 
   useEffect(() => {
-    if (typeof provider === "string") {
-      // Remove provider selector since the provider is determined.
-      updateSearchConfig("cloudProvider", [
-        provider.toUpperCase() as CloudProvider,
-      ]);
-    }
-  }, [provider, updateSearchConfig]);
+    // Remove provider selector since the provider is determined.
+    updateSearchConfig("cloudProvider", [name.toUpperCase() as CloudProvider]);
+  }, [name, updateSearchConfig]);
 
   return (
-    <MainLayout title="The Ultimate AWS RDS and Google Cloud SQL Instance Pricing Sheet">
+    <MainLayout
+      title={`The Ultimate ${
+        name === "aws" ? "AWS RDS" : "Google Cloud SQL"
+      } Instance Pricing Sheet`}
+    >
       <div className="mx-5 mt-4 pb-2">
         <ButtonGroup type="reset" />
         <RegionMenu availableRegionList={availableRegionList} />
@@ -192,7 +215,7 @@ const Provider: NextPage = () => {
         <CompareTable
           dataSource={dataSource}
           setDataSource={setDataSource}
-          generateTableData={generateTableData}
+          generateTableData={memoizedGenerate}
           hideProviderIcon={true}
         />
       </div>
@@ -201,3 +224,31 @@ const Provider: NextPage = () => {
 };
 
 export default Provider;
+
+export const getStaticPaths = () => ({
+  paths: [{ params: { provider: "aws" } }, { params: { provider: "gcp" } }],
+  fallback: false,
+});
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const { provider: providerName } = context.params as unknown as Params;
+  const sourceFileName = "dbInstance.json";
+  const data = (await import(`../../../data/${sourceFileName}`))
+    .default as DBInstance[];
+  // For SEO, showing the first page is enough. So we only need to
+  // pass the first page of data to the page. Passing the whole large
+  // `data` will make this page twice as large to reduce performance.
+  const firstPageData = data
+    .filter((instance) => instance.cloudProvider === providerName.toUpperCase())
+    .slice(0, tablePaginationConfig.defaultPageSize);
+
+  return {
+    props: {
+      serverSideCompareTableData: generateTableData(
+        firstPageData,
+        SearchConfigDefault
+      ),
+      name: providerName,
+    },
+  };
+};

--- a/frontend/types/table.ts
+++ b/frontend/types/table.ts
@@ -34,3 +34,8 @@ export interface RelatedType {
   CPU: number;
   memory: number;
 }
+
+export const tablePaginationConfig = {
+  defaultPageSize: 50,
+  hideOnSinglePage: true,
+};

--- a/frontend/utils/index.ts
+++ b/frontend/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./price";
 export * from "./assets";
 export * from "./config";
 export * from "./table";
+export * from "./instance";
 
 export const isEmptyArray = (arr: any[] | undefined) => {
   if (Array.isArray(arr) && !arr.length) {

--- a/frontend/utils/instance.ts
+++ b/frontend/utils/instance.ts
@@ -1,0 +1,39 @@
+import { CloudProvider } from "@/types";
+
+export const getInstanceClass = (
+  name: string,
+  provider: CloudProvider
+): string => {
+  switch (provider) {
+    case "AWS":
+      return `${name.split(".").slice(0, 2).join(".")}.`;
+    case "GCP":
+      return `${name.split("-").slice(0, 2).join("-")}-`;
+    default:
+      return "";
+  }
+};
+
+export const getInstanceFamily = (
+  name: string,
+  provider: CloudProvider
+): string => {
+  switch (provider) {
+    case "AWS":
+      return name.split(".")[1].charAt(0);
+    default:
+      return "";
+  }
+};
+
+export const getInstanceSize = (
+  name: string,
+  provider: CloudProvider
+): string => {
+  switch (provider) {
+    case "AWS":
+      return name.split(".")[2];
+    default:
+      return "";
+  }
+};


### PR DESCRIPTION
Next.js enables [SSG (Static Site Generation)](https://nextjs.org/docs/basic-features/pages#static-generation-recommended) by default for every project though, before this PR, DB Cost produces little content in the build time. It looks like this (with JavaScipt disabled):

![Shot-2022-10-20-Microsoft Edge-AbLqmwsC](https://user-images.githubusercontent.com/56376387/196881327-4393614e-83f1-4c4a-ba8a-714131c9b4dd.png)

All the content (these tables) are empty because these table data's generation depends on some React runtime hooks such as `useEffect`, which are [not executed](https://nextjs.org/docs/migrating/from-create-react-app#safely-accessing-web-apis) during `next build`.

This is not SEO-friendly since GoogleBots cannot get the content of the page at a single fetch. 

We can do something to make the product more contentful. Take the instance detail page as an example. In these pages, we already know what to display at build time (available regions and pricing about the exact instance), so why do we generate them until client-side JS runs? We can fill in the table ahead of time so that even if client-side JS is disabled, users (crawlers) still get the full content. So we can turn to generate these data at the build time.

There's another question: do we still need table data maintained in runtime JS? The answer is YES because we allow users to operate on our tables (filtering/sorting). These operations can't live without client-side JavaScript. So we should make tables both compatible with server-side generated data (for bots/crawlers) and client-side generated data (for users/humans).

[Here](https://nextjs.org/docs/messages/react-hydration-error#possible-ways-to-fix-it)'s an inspiring solution to this problem. We can set server-side generated data as the default value of the state that Table components consume, and re-initialize it inside `useEffect`s to take control over them during client-side JavaScript runtime.

1. Set server-side generated data as the default data source.
```ts
const [dataSource, setDataSource] = useState<DataSource[]>(serverSideCompareTableData);
```

2. Reset its value inside a client-side-only `useEffect` hook.
```ts
useEffect(() => {
  startTransition(() => {
    setDataSource(generateTableData());
  });
}, [generateTableData, setDataSource]);
```

3. It is the same for other pages.

Now our generated pages become contentful even without client-side JavaScript enabled. (An interactive chart is not helpful to SEO, so I'm letting it go. <3)

![Shot-2022-10-20-Microsoft Edge-Mvfl6MvH](https://user-images.githubusercontent.com/56376387/196889519-d76cf6a4-1972-45ab-812d-92b12b176868.png)