### PR TITLE
chore: upgrade to Next 13

### DIFF
--- a/frontend/components/ButtonGroup.tsx
+++ b/frontend/components/ButtonGroup.tsx
@@ -25,9 +25,7 @@ const ButtonGroup: React.FC<Props> = ({ type }) => {
         </Button>
       ) : (
         <Link href="/" passHref>
-          <a>
-            <Button className="mr-2">Back to Dashboard</Button>
-          </a>
+          <Button className="mr-2">Back to Dashboard</Button>
         </Link>
       )}
       <Button type={isCopied ? "dashed" : "default"} onClick={handleCopy}>

--- a/frontend/components/CompareTable.tsx
+++ b/frontend/components/CompareTable.tsx
@@ -296,7 +296,7 @@ const CompareTable: React.FC<Props> = ({
                         </div>
                       )}
                       <Link href={`/instance/${name}`} passHref>
-                        <a>{name}</a>
+                        {name}
                       </Link>
                     </div>
                   );
@@ -330,7 +330,7 @@ const CompareTable: React.FC<Props> = ({
                   <span>{region}</span>
                 ) : (
                   <Link href={`/region/${slug(region)}`} passHref>
-                    <a>{region}</a>
+                    {region}
                   </Link>
                 ),
               shouldCellUpdate: (record: DataSource, prevRecord: DataSource) =>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -26,8 +26,8 @@ const Header: React.FC = () => {
               <Image
                 src="/icons/dbcost-logo-full.webp"
                 alt="DB Cost"
-                layout="fill"
-                objectFit="contain"
+                fill
+                style={{ objectFit: "contain" }}
               />
             </div>
           </Link>
@@ -76,8 +76,8 @@ const Header: React.FC = () => {
                   <Image
                     src="/icons/bytebase-cncf.svg"
                     alt="Bytebase"
-                    layout="fill"
-                    objectFit="contain"
+                    fill
+                    style={{ objectFit: "contain" }}
                   />
                 </div>
               </Tooltip>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -19,32 +19,28 @@ const Header: React.FC = () => {
         {/* logo and provider entries */}
         <div className="flex flex-row items-center gap-4 flex-grow shrink-0 basis-0">
           <Link href="/" passHref>
-            <a>
-              <div
-                className="relative w-32 h-8 cursor-pointer"
-                onClick={() => void resetSearchConfig()}
-              >
-                <Image
-                  src="/icons/dbcost-logo-full.webp"
-                  alt="DB Cost"
-                  layout="fill"
-                  objectFit="contain"
-                />
-              </div>
-            </a>
+            <div
+              className="relative w-32 h-8 cursor-pointer"
+              onClick={() => void resetSearchConfig()}
+            >
+              <Image
+                src="/icons/dbcost-logo-full.webp"
+                alt="DB Cost"
+                layout="fill"
+                objectFit="contain"
+              />
+            </div>
           </Link>
           {providerList.map((provider: string) => (
             <Link href={`/provider/${provider}`} key={provider} passHref>
-              <a>
-                <span
-                  className={`${
-                    providerInRoute === provider ? "border-b" : ""
-                  } h-8 text-lg pt-0.5 text-white cursor-pointer`}
-                  onClick={() => void resetSearchConfig()}
-                >
-                  {provider.toUpperCase()}
-                </span>
-              </a>
+              <span
+                className={`${
+                  providerInRoute === provider ? "border-b" : ""
+                } h-8 text-lg pt-0.5 text-white cursor-pointer`}
+                onClick={() => void resetSearchConfig()}
+              >
+                {provider.toUpperCase()}
+              </span>
             </Link>
           ))}
         </div>

--- a/frontend/components/Icon.tsx
+++ b/frontend/components/Icon.tsx
@@ -12,8 +12,8 @@ const Icon: React.FC<Props> = ({ name }) => {
     <Image
       src={getIconPath(`${name}.png`)}
       alt={name}
-      layout="fill"
-      objectFit="contain"
+      fill
+      style={{ objectFit: "contain" }}
     />
   );
 };

--- a/frontend/components/RelatedTable.tsx
+++ b/frontend/components/RelatedTable.tsx
@@ -25,7 +25,7 @@ const RelatedTable: React.FC<Props> = ({ title, instance, dataSource }) => {
           name
         ) : (
           <Link href={`/instance/${name}`} passHref>
-            <a>{name}</a>
+            {name}
           </Link>
         ),
     },

--- a/frontend/components/SearchMenu.tsx
+++ b/frontend/components/SearchMenu.tsx
@@ -75,8 +75,8 @@ const SearchMenu: React.FC<Props> = ({
                   <Image
                     src={provider.src}
                     alt="aws"
-                    layout="fill"
-                    objectFit="contain"
+                    fill
+                    style={{ objectFit: "contain" }}
                   />
                 </div>
               </Checkbox>
@@ -99,8 +99,8 @@ const SearchMenu: React.FC<Props> = ({
                 <Image
                   src={engine.src}
                   alt="aws"
-                  layout="fill"
-                  objectFit="contain"
+                  fill
+                  style={{ objectFit: "contain" }}
                 />
               </div>
             </Checkbox>

--- a/frontend/layouts/main.tsx
+++ b/frontend/layouts/main.tsx
@@ -16,11 +16,6 @@ const Main: React.FC<Props> = ({ children, headTitle, title }) => {
           {headTitle ?? "DB Cost | RDS & Cloud SQL Instance Pricing Sheet"}
         </title>
         <link rel="icon" href="/favicon.ico" />
-        <script
-          defer
-          data-domain="dbcost.com"
-          src="https://plausible.io/js/script.js"
-        ></script>
       </Head>
       <Header />
       <main className="flex flex-grow justify-center">

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,0 +1,21 @@
+import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <Script
+          strategy="beforeInteractive"
+          data-domain="dbcost.com"
+          src="https://plausible.io/js/script.js"
+        ></Script>
+      </Head>
+
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/frontend/pages/region/[region].tsx
+++ b/frontend/pages/region/[region].tsx
@@ -246,8 +246,12 @@ const Region: NextPage<Props> = ({
               .map((region) => (
                 <React.Fragment key={region}>
                   <Divider type="vertical" />
-                  <Link href={`/region/${slug(region)}`} passHref>
-                    <a className="whitespace-nowrap leading-6">{region}</a>
+                  <Link
+                    href={`/region/${slug(region)}`}
+                    passHref
+                    className="whitespace-nowrap leading-6"
+                  >
+                    {region}
                   </Link>
                 </React.Fragment>
               ))}


### PR DESCRIPTION
- Update `next/link`: remove `<a>`.
- Update `next/image`: drop legacy attributes.
- Update `<script>`: use `next/script` instead of row `<script>`.