### PR TITLE
chore: add missing sizes prop on images

### DIFF
--- a/frontend/components/CompareTable.tsx
+++ b/frontend/components/CompareTable.tsx
@@ -209,7 +209,10 @@ const CompareTable: React.FC<Props> = ({
         return (
           <div className="flex justify-between">
             <div className="relative top-1 w-6 h-5">
-              <Icon name={`db-${record.engineType.toLowerCase()}`} />
+              <Icon
+                name={`db-${record.engineType.toLowerCase()}`}
+                sizes="1.5rem"
+              />
             </div>
             <span className="font-mono">{`$${commitment.usd}`}</span>
           </div>
@@ -292,6 +295,7 @@ const CompareTable: React.FC<Props> = ({
                         <div className="relative !w-5 h-5 mr-2">
                           <Icon
                             name={`provider-${record.cloudProvider.toLowerCase()}`}
+                            sizes="1.25rem"
                           />
                         </div>
                       )}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -27,6 +27,7 @@ const Header: React.FC = () => {
                 src="/icons/dbcost-logo-full.webp"
                 alt="DB Cost"
                 fill
+                sizes="8rem"
                 style={{ objectFit: "contain" }}
               />
             </div>
@@ -77,6 +78,7 @@ const Header: React.FC = () => {
                     src="/icons/bytebase-cncf.svg"
                     alt="Bytebase"
                     fill
+                    sizes="16rem"
                     style={{ objectFit: "contain" }}
                   />
                 </div>

--- a/frontend/components/Icon.tsx
+++ b/frontend/components/Icon.tsx
@@ -4,15 +4,18 @@ import { getIconPath } from "@/utils";
 
 interface Props {
   name: string;
+  // https://nextjs.org/docs/api-reference/next/image#sizes
+  sizes: string;
 }
 
 /* Pure Component */
-const Icon: React.FC<Props> = ({ name }) => {
+const Icon: React.FC<Props> = ({ name, sizes }) => {
   return (
     <Image
       src={getIconPath(`${name}.png`)}
       alt={name}
       fill
+      sizes={sizes}
       style={{ objectFit: "contain" }}
     />
   );

--- a/frontend/components/RegionMenu.tsx
+++ b/frontend/components/RegionMenu.tsx
@@ -271,12 +271,12 @@ const RegionMenu: React.FC<Props> = ({ availableRegionList }) => {
               <Checkbox value={region.name}>{region.name}</Checkbox>
               {region.providerCode.has("AWS") && (
                 <div className="relative top-1 w-5 h-4 mr-2">
-                  <Icon name="provider-aws" />
+                  <Icon name="provider-aws" sizes="1.25rem" />
                 </div>
               )}
               {region.providerCode.has("GCP") && (
                 <div className="relative top-1 w-4 h-4">
-                  <Icon name="provider-gcp" />
+                  <Icon name="provider-gcp" sizes="1rem" />
                 </div>
               )}
             </div>

--- a/frontend/components/SearchMenu.tsx
+++ b/frontend/components/SearchMenu.tsx
@@ -81,6 +81,7 @@ const SearchMenu: React.FC<Props> = ({
                       src={provider.src}
                       alt="aws"
                       fill
+                      sizes="1.5rem"
                       style={{ objectFit: "contain" }}
                     />
                   </div>
@@ -105,6 +106,7 @@ const SearchMenu: React.FC<Props> = ({
                   src={engine.src}
                   alt="aws"
                   fill
+                  sizes="1.5rem"
                   style={{ objectFit: "contain" }}
                 />
               </div>

--- a/frontend/components/SearchMenu.tsx
+++ b/frontend/components/SearchMenu.tsx
@@ -79,7 +79,7 @@ const SearchMenu: React.FC<Props> = ({
                   >
                     <Image
                       src={provider.src}
-                      alt="aws"
+                      alt={provider.key}
                       fill
                       sizes="1.5rem"
                       style={{ objectFit: "contain" }}
@@ -104,7 +104,7 @@ const SearchMenu: React.FC<Props> = ({
               <div className="relative top-1 w-6 h-5">
                 <Image
                   src={engine.src}
-                  alt="aws"
+                  alt={engine.key}
                   fill
                   sizes="1.5rem"
                   style={{ objectFit: "contain" }}


### PR DESCRIPTION
Ref: https://nextjs.org/docs/api-reference/next/image#sizes

<img width="1205" alt="2022-11-30-Microsoft Edge-g1LoZf7X" src="https://user-images.githubusercontent.com/56376387/204701003-acea0151-95ae-485e-b676-d6d6518dad71.png">