### PR TITLE
chore: update region list

### DIFF
--- a/frontend/utils/region.ts
+++ b/frontend/utils/region.ts
@@ -27,6 +27,11 @@ export const regionCodeNameSlugMap: [string, string, string][] = [
   ["us-west-1", "US West (N. California)", "us-west-n-california"],
   ["us-west-2", "US West (Oregon)", "us-west-oregon"],
   ["us-west-2-lax-1", "US West (Los Angeles)", "us-west-los-angeles"],
+  ["ap-south-2", "Asia Pacific (Hyderabad)", "asia-pacific-hyderabad"],
+  ["eu-central-2", "Europe (Zurich)", "europe-zurich"],
+  ["eu-south-2", "Europe (Spain)", "europe-spain"],
+  ["me-central-1", "Middle East (UAE)", "middle-east-uae"],
+
   // GCP
   ["asia-east1", "Asia Pacific (Taiwan)", "asia-pacific-taiwan"],
   ["asia-east2", "Asia Pacific (Hong Kong)", "asia-pacific-hong-kong"],
@@ -63,6 +68,11 @@ export const regionCodeNameSlugMap: [string, string, string][] = [
   ["us-west2", "US West (Los Angeles)", "us-west-los-angeles"],
   ["us-west3", "US West (Salt Lake City)", "us-west-salt-lake-city"],
   ["us-west4", "US West (Las Vegas)", "us-west-las-vegas"],
+  ["us-south1", "US South (Dallas)", "us-south-dallas"],
+  ["me-west1", "Middle East (Tel Aviv)", "middle-east-tel-aviv"],
+  ["us-east5", "North America (Columbus)", "north-america-columbus"],
+  ["europe-southwest1", "Europe (Madrid)", "europe-madrid"],
+  ["us-east7", "US East (Alabama)", "us-east-alabama"],
 ];
 
 export const getRegionName = (regionCode: string): string => {


### PR DESCRIPTION
![2022-12-02-Microsoft Edge-tpgRcNVg](https://user-images.githubusercontent.com/56376387/205270175-f620d9ca-adc6-409e-b701-1c4be4040321.png)

This reduces the unknown "Other" regions count. But there're still two Other regions: Other (us-central2) and Other (). 

I cannot find a region named "us-central2" on the Internet. So I'm not sure if it's a mistake in the official API or if there's sth wrong with the seeding code. I'll look deeper into it.