### PR TITLE
fix: make hourly price consistent

### DIFF
--- a/frontend/pages/compare/[comparison].tsx
+++ b/frontend/pages/compare/[comparison].tsx
@@ -368,7 +368,10 @@ export const getStaticProps: GetStaticProps = async (context) => {
     const instanceB = data.find((instance) => instance.name === comparerB)!;
 
     [instanceA, instanceB].forEach((instance) => {
-      const term = instance.regionList[0].termList.find(
+      const term = (
+        instance.regionList.find((region) => region.code === virginiaCode) ||
+        instance.regionList[0]
+      ).termList.find(
         (term) => term.type === "OnDemand" && term.databaseEngine === "MYSQL"
       );
       dataSource.push({


### PR DESCRIPTION
Use the price in Virginia by default to make it the same as below in the table.
![2022-12-06-Microsoft Edge-7LCAC9Mi](https://user-images.githubusercontent.com/56376387/205803628-76ce721b-eeec-4608-be0a-c3a10b24ba5c.png)
